### PR TITLE
Benchmark representative values (~7 characters in most cases)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,10 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = 11
+sourceCompatibility = 1.8
 
 dependencies {
-    annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.34'
+    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.34'
     jmh 'org.openjdk.jmh:jmh-core:1.34'
 }
 


### PR DESCRIPTION
JDK17 results

```
Benchmark                               Mode  Cnt    Score    Error  Units
FormatBenchmarks.stringFormat           avgt    5  431.935 ± 37.370  ns/op
FormatBenchmarks.zeroPadPrefixesArray   avgt    5   38.261 ±  1.599  ns/op
FormatBenchmarks.zeroPadPrefixesSwitch  avgt    5   26.841 ±  2.509  ns/op
FormatBenchmarks.zeroPadProposed        avgt    5   39.199 ±  1.526  ns/op
```

JDK8 results
```
Benchmark                               Mode  Cnt    Score    Error  Units
FormatBenchmarks.stringFormat           avgt    5  514.358 ± 61.744  ns/op
FormatBenchmarks.zeroPadPrefixesArray   avgt    5   56.109 ±  2.994  ns/op
FormatBenchmarks.zeroPadPrefixesSwitch  avgt    5   43.931 ±  6.315  ns/op
FormatBenchmarks.zeroPadProposed        avgt    5   70.111 ±  5.690  ns/op
```